### PR TITLE
rename `kdoc-wrapping` to `kdoc-content-wrapping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.0.7-SNAPSHOT (unreleased)
 
+### Changed
+
+- The rule `KDocWrappingRule` (`kdoc-wrapping`) has been renamed
+  to `KDocContentWrappingRule`/`kdoc-content-wrapping` in order to avoid a conflict with
+  the [new experimental rule](https://pinterest.github.io/ktlint/rules/experimental/#kdoc-wrapping)
+  in the KtLint library.
+
 ## [1.0.6] - 2023-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ include:
 # KtLint specific settings
 # noinspection EditorConfigKeyCorrectness
 [{*.kt,*.kts}]
+ktlint_kt-rules_kdoc-content-wrapping = enabled
 ktlint_kt-rules_kdoc-indent-after-leading-asterisk = enabled
 ktlint_kt-rules_kdoc-leading-asterisk = enabled
 ktlint_kt-rules_kdoc-tag-order = enabled
 ktlint_kt-rules_kdoc-tag-param-or-property = enabled
-ktlint_kt-rules_kdoc-wrapping = enabled
 ktlint_kt-rules_no-duplicate-copyright-header = enabled
 ktlint_kt-rules_no-leading-blank-lines = enabled
 ktlint_kt-rules_no-since-in-kdoc = enabled
@@ -40,19 +40,19 @@ ktlint_kt-rules_wrapping_style = equal
 
 <!--doks END-->
 
-|                  Rule                  |                                                                Description                                                                 |
-| :------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
-|   KDocIndentAfterLeadingAsteriskRule   |                    ensures that there's a space after every leading asterisk in a KDoc comment, except for blank lines                     |
-|        KDocLeadingAsteriskRule         |                                 ensures that the leading asterisk in a KDoc comment is followed by a space                                 |
-|       KDocTagParamOrPropertyRule       |                     ensures that KDoc tags use `@property` for vals or vars, and `@param` for non-property parameters.                     |
-|            KDocTagOrderRule            |                                    sorts KDoc tags by their declaration order in the class or function                                     |
-|            KDocWrappingRule            |                                    ensures consistent wrapping of KDoc comments to improve readability                                     |
-|     NoDuplicateCopyrightHeaderRule     |                                            ensures that each file has only one copyright header                                            |
-|        NoLeadingBlankLinesRule         |                                           ensures that there are no leading blank lines in files                                           |
-|           NoSinceInKDocRule            |                                            ensures that there is no @since tag in KDoc comments                                            |
-|    NoSpaceInTargetedAnnotationRule     | ensures that targeted annotations (annotations with a target specifier such as @get:, @set:, etc.) have no space before or after the colon |
-| NoTrailingSpacesInRawStringLiteralRule |                                      ensures that there are no trailing spaces in raw string literals                                      |
-|    NoUselessConstructorKeywordRule     |                                    removes the unnecessary constructor keyword from class constructors                                     |
+|                   Rule                    |                                                                Description                                                                 |
+| :---------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: |
+|          `kdoc-content-wrapping`          |                                    ensures consistent wrapping of KDoc comments to improve readability                                     |
+|   `kdoc-indent-after-leading-asterisk`    |                    ensures that there's a space after every leading asterisk in a KDoc comment, except for blank lines                     |
+|          `kdoc-leading-asterisk`          |                                 ensures that the leading asterisk in a KDoc comment is followed by a space                                 |
+|             `kdoc-tag-order`              |                                    sorts KDoc tags by their declaration order in the class or function                                     |
+|       `kdoc-tag-param-or-property`        |                     ensures that KDoc tags use `@property` for vals or vars, and `@param` for non-property parameters.                     |
+|      `no-duplicate-copyright-header`      |                                            ensures that each file has only one copyright header                                            |
+|         `no-leading-blank-lines`          |                                           ensures that there are no leading blank lines in files                                           |
+|            `no-since-in-kdoc`             |                                            ensures that there is no @since tag in KDoc comments                                            |
+|   `no-space-in-annotation-with-target`    | ensures that targeted annotations (annotations with a target specifier such as @get:, @set:, etc.) have no space before or after the colon |
+| `no-trailing-space-in-raw-string-literal` |                                      ensures that there are no trailing spaces in raw string literals                                      |
+|     `no-useless-constructor-keyword`      |                                    removes the unnecessary constructor keyword from class constructors                                     |
 
 ## Gradle Usage
 

--- a/api/ktrules.api
+++ b/api/ktrules.api
@@ -3,6 +3,15 @@ public final class com/rickbusarow/ktrules/KtRulesRuleSetProvider : com/pinteres
 	public fun getRuleProviders ()Ljava/util/Set;
 }
 
+public final class com/rickbusarow/ktrules/rules/KDocContentWrappingRule : com/pinterest/ktlint/core/Rule, com/pinterest/ktlint/core/api/UsesEditorConfigProperties {
+	public fun <init> ()V
+	public fun beforeFirstNode (Ljava/util/Map;)V
+	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
+	public fun getEditorConfigProperties ()Ljava/util/List;
+	public fun getEditorConfigValue (Ljava/util/Map;Lcom/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty;)Ljava/lang/Object;
+	public fun writeEditorConfigProperty (Ljava/util/Map;Lcom/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty;Lcom/pinterest/ktlint/core/api/editorconfig/CodeStyleValue;)Ljava/lang/String;
+}
+
 public final class com/rickbusarow/ktrules/rules/KDocIndentAfterLeadingAsteriskRule : com/pinterest/ktlint/core/Rule {
 	public fun <init> ()V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
@@ -21,15 +30,6 @@ public final class com/rickbusarow/ktrules/rules/KDocTagOrderRule : com/pinteres
 public final class com/rickbusarow/ktrules/rules/KDocTagParamOrPropertyRule : com/pinterest/ktlint/core/Rule {
 	public fun <init> ()V
 	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
-}
-
-public final class com/rickbusarow/ktrules/rules/KDocWrappingRule : com/pinterest/ktlint/core/Rule, com/pinterest/ktlint/core/api/UsesEditorConfigProperties {
-	public fun <init> ()V
-	public fun beforeFirstNode (Ljava/util/Map;)V
-	public fun beforeVisitChildNodes (Lorg/jetbrains/kotlin/com/intellij/lang/ASTNode;ZLkotlin/jvm/functions/Function3;)V
-	public fun getEditorConfigProperties ()Ljava/util/List;
-	public fun getEditorConfigValue (Ljava/util/Map;Lcom/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty;)Ljava/lang/Object;
-	public fun writeEditorConfigProperty (Ljava/util/Map;Lcom/pinterest/ktlint/core/api/editorconfig/EditorConfigProperty;Lcom/pinterest/ktlint/core/api/editorconfig/CodeStyleValue;)Ljava/lang/String;
 }
 
 public final class com/rickbusarow/ktrules/rules/NoDuplicateCopyrightHeaderRule : com/pinterest/ktlint/core/Rule {

--- a/src/main/kotlin/com/rickbusarow/ktrules/KtRulesRuleSetProvider.kt
+++ b/src/main/kotlin/com/rickbusarow/ktrules/KtRulesRuleSetProvider.kt
@@ -20,11 +20,11 @@ package com.rickbusarow.ktrules
 import com.google.auto.service.AutoService
 import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.RuleSetProviderV2
+import com.rickbusarow.ktrules.rules.KDocContentWrappingRule
 import com.rickbusarow.ktrules.rules.KDocIndentAfterLeadingAsteriskRule
 import com.rickbusarow.ktrules.rules.KDocLeadingAsteriskRule
 import com.rickbusarow.ktrules.rules.KDocTagOrderRule
 import com.rickbusarow.ktrules.rules.KDocTagParamOrPropertyRule
-import com.rickbusarow.ktrules.rules.KDocWrappingRule
 import com.rickbusarow.ktrules.rules.NoDuplicateCopyrightHeaderRule
 import com.rickbusarow.ktrules.rules.NoLeadingBlankLinesRule
 import com.rickbusarow.ktrules.rules.NoSinceInKDocRule
@@ -46,11 +46,11 @@ class KtRulesRuleSetProvider : RuleSetProviderV2(
 
   override fun getRuleProviders(): Set<RuleProvider> {
     return setOf(
+      RuleProvider { KDocContentWrappingRule() },
       RuleProvider { KDocIndentAfterLeadingAsteriskRule() },
       RuleProvider { KDocLeadingAsteriskRule() },
       RuleProvider { KDocTagOrderRule() },
       RuleProvider { KDocTagParamOrPropertyRule() },
-      RuleProvider { KDocWrappingRule() },
       RuleProvider { NoDuplicateCopyrightHeaderRule() },
       RuleProvider { NoLeadingBlankLinesRule() },
       RuleProvider { NoSinceInKDocRule() },

--- a/src/main/kotlin/com/rickbusarow/ktrules/rules/KDocContentWrappingRule.kt
+++ b/src/main/kotlin/com/rickbusarow/ktrules/rules/KDocContentWrappingRule.kt
@@ -59,8 +59,8 @@ import kotlin.LazyThreadSafetyMode.NONE
  *
  * @since 1.0.0
  */
-class KDocWrappingRule : Rule(
-  id = "kdoc-wrapping",
+class KDocContentWrappingRule : Rule(
+  id = "kdoc-content-wrapping",
   visitorModifiers = setOf(
     RunAfterRule("kdoc-leading-asterisk"),
     RunAfterRule("kdoc-indent-after-leading-asterisk")

--- a/src/test/kotlin/com/rickbusarow/ktrules/EditorConfigPropertiesTest.kt
+++ b/src/test/kotlin/com/rickbusarow/ktrules/EditorConfigPropertiesTest.kt
@@ -34,6 +34,7 @@ class EditorConfigPropertiesTest : Tests {
 
     val ids by lazy {
       ruleProviders.map { it.createNewRuleInstance().id }
+        .sorted()
         .plus(ALL_PROPERTIES.map { it.name.removePrefix("${RULES_PREFIX}_") })
     }
 
@@ -44,11 +45,11 @@ class EditorConfigPropertiesTest : Tests {
       # KtLint specific settings
       # noinspection EditorConfigKeyCorrectness
       [{*.kt,*.kts}]
+      ktlint_kt-rules_kdoc-content-wrapping = enabled
       ktlint_kt-rules_kdoc-indent-after-leading-asterisk = enabled
       ktlint_kt-rules_kdoc-leading-asterisk = enabled
       ktlint_kt-rules_kdoc-tag-order = enabled
       ktlint_kt-rules_kdoc-tag-param-or-property = enabled
-      ktlint_kt-rules_kdoc-wrapping = enabled
       ktlint_kt-rules_no-duplicate-copyright-header = enabled
       ktlint_kt-rules_no-leading-blank-lines = enabled
       ktlint_kt-rules_no-since-in-kdoc = enabled

--- a/src/test/kotlin/com/rickbusarow/ktrules/rules/KDocContentWrappingRuleTest.kt
+++ b/src/test/kotlin/com/rickbusarow/ktrules/rules/KDocContentWrappingRuleTest.kt
@@ -27,10 +27,10 @@ import com.pinterest.ktlint.test.format as ktlintTestFormat
 import com.pinterest.ktlint.test.lint as ktlintTestLint
 
 @Suppress("SpellCheckingInspection")
-class KDocWrappingRuleTest : Tests {
+class KDocContentWrappingRuleTest : Tests {
 
   val rules = setOf(
-    RuleProvider { KDocWrappingRule() }
+    RuleProvider { KDocContentWrappingRule() }
   )
 
   @Test


### PR DESCRIPTION
This avoids a conflict with the `kdoc-wrapping` rule currently in the experimental stage in the main KtLint library.