### PR TITLE
don't make the `project_version` editorconfig property look like a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.1.4-SNAPSHOT (unreleased)
 
+### Changed
+
+- The editorconfig properties `ktlint_kt-rules_project_version` and `ktlint_kt-rules_wrapping_style`
+  have been deprecated and replaced with `kt-rules_project_version` and `kt-rules_wrapping_style`
+  respectively.  This is to avoid KtLint trying to parse them as RuleIds.
+
+
 ## [1.1.3] - 2023-06-29
 
 The default artifact is now updated

--- a/src/main/kotlin/com/rickbusarow/ktrules/ec4j/properties.kt
+++ b/src/main/kotlin/com/rickbusarow/ktrules/ec4j/properties.kt
@@ -18,12 +18,15 @@ package com.rickbusarow.ktrules.ec4j
 import com.rickbusarow.ktrules.compat.EditorConfigProperty
 import com.rickbusarow.ktrules.rules.ec4j.NullableStringPropertyType
 import com.rickbusarow.ktrules.rules.internal.WrappingStyle.Companion.WRAPPING_STYLE_PROPERTY
+import com.rickbusarow.ktrules.rules.internal.WrappingStyle.Companion.WRAPPING_STYLE_PROPERTY_DEPRECATED
 
 internal const val RULES_PREFIX = "ktlint_kt-rules"
 
 internal val ALL_PROPERTIES by lazy {
   setOf(
+    PROJECT_VERSION_PROPERTY_DEPRECATED,
     PROJECT_VERSION_PROPERTY,
+    WRAPPING_STYLE_PROPERTY_DEPRECATED,
     WRAPPING_STYLE_PROPERTY
   )
 }
@@ -33,11 +36,34 @@ internal val ALL_PROPERTIES by lazy {
  *
  * @since 1.1.2
  */
-internal val PROJECT_VERSION_PROPERTY: EditorConfigProperty<String?> by lazy {
+@Deprecated("to be removed in the next release.  Use `PROJECT_VERSION_PROPERTY` instead.")
+internal val PROJECT_VERSION_PROPERTY_DEPRECATED: EditorConfigProperty<String?> by lazy {
 
   val projectVersionPropertyType = NullableStringPropertyType(
     "${RULES_PREFIX}_project_version",
     "the current project version as a literal string"
+  )
+
+  EditorConfigProperty(
+    name = projectVersionPropertyType.name,
+    type = projectVersionPropertyType,
+    defaultValue = null,
+    deprecationError = "Use just kt-rules_project_version instead",
+    propertyMapper = { property, _ ->
+
+      property?.sourceValue?.trim('"', '\'')
+    }
+  )
+}
+
+/** Returns a valid `null` value if the property isn't set */
+internal val PROJECT_VERSION_PROPERTY: EditorConfigProperty<String?> by lazy {
+
+  val projectVersionPropertyType = NullableStringPropertyType(
+    // don't prefix this with `ktlint_` because it's not a rule ID.
+    // KtLint's parsing will fail if it sees this editorconfig property.
+    name = "kt-rules_project_version",
+    description = "the current project version as a literal string"
   )
 
   EditorConfigProperty(

--- a/src/main/kotlin/com/rickbusarow/ktrules/rules/internal/WrappingStyle.kt
+++ b/src/main/kotlin/com/rickbusarow/ktrules/rules/internal/WrappingStyle.kt
@@ -51,10 +51,39 @@ enum class WrappingStyle(val displayValue: String) {
      * @see WrappingStyle
      * @since 1.1.2
      */
-    val WRAPPING_STYLE_PROPERTY: EditorConfigProperty<WrappingStyle> by lazy(NONE) {
+    @Deprecated("Use `kt-rules_wrapping_style` instead.")
+    val WRAPPING_STYLE_PROPERTY_DEPRECATED: EditorConfigProperty<WrappingStyle> by lazy(NONE) {
       val wrappingStylePropertyType: LowerCasingPropertyType<WrappingStyle> =
         LowerCasingPropertyType(
           "${RULES_PREFIX}_wrapping_style",
+          values().map { it.displayValue }.toString(),
+          PropertyType.PropertyValueParser.EnumValueParser(WrappingStyle::class.java),
+          values().mapToSet { it.displayValue }
+        )
+
+      EditorConfigProperty(
+        name = wrappingStylePropertyType.name,
+        type = wrappingStylePropertyType,
+        defaultValue = MINIMUM_RAGGED,
+        deprecationError = "Use `kt-rules_wrapping_style` instead.",
+        propertyMapper = { property, _ ->
+
+          val name = property?.sourceValue?.trim('"', '\'')?.lowercase()
+
+          values().firstOrNull { it.displayValue == name }
+        },
+        propertyWriter = { it.displayValue }
+      )
+    }
+
+    /**
+     * @see WrappingStyle
+     * @since 1.1.2
+     */
+    val WRAPPING_STYLE_PROPERTY: EditorConfigProperty<WrappingStyle> by lazy(NONE) {
+      val wrappingStylePropertyType: LowerCasingPropertyType<WrappingStyle> =
+        LowerCasingPropertyType(
+          "kt-rules_wrapping_style",
           values().map { it.displayValue }.toString(),
           PropertyType.PropertyValueParser.EnumValueParser(WrappingStyle::class.java),
           values().mapToSet { it.displayValue }

--- a/src/test/kotlin/com/rickbusarow/ktrules/EditorConfigPropertiesTest.kt
+++ b/src/test/kotlin/com/rickbusarow/ktrules/EditorConfigPropertiesTest.kt
@@ -63,7 +63,9 @@ class EditorConfigPropertiesTest : Tests {
       ktlint_kt-rules_no-useless-constructor-keyword = enabled
 
       ktlint_kt-rules_project_version = 1.0.0
+      kt-rules_project_version = 1.0.0
       ktlint_kt-rules_wrapping_style = equal
+      kt-rules_wrapping_style = equal
 
       [{*.kt,*.kts}]
       # actual kotlin settings go here
@@ -88,7 +90,7 @@ class EditorConfigPropertiesTest : Tests {
   @Test
   fun `defaultConfig property matches all defined config property IDs`() = test {
 
-    val ruleReg = """(ktlint_kt-rules_.*?) ?=.*""".toRegex()
+    val ruleReg = """((?:ktlint_)?kt-rules_.*?) ?=.*""".toRegex()
 
     val parsedPropertyIds = defaultConfig
       .lines()


### PR DESCRIPTION
KtLint tries to parse it into a Rule since it starts with the rule prefix.

```
java.lang.IllegalArgumentException: Rule with id 'kt-rules:project_version' must match regexp '[a-z]+(-[a-z]+)*:[a-z]+(-[a-z]+)*'
        at com.pinterest.ktlint.rule.engine.core.internal.IdNamingPolicy.enforceRuleIdNaming$ktlint_rule_engine_core(IdNamingPolicy.kt:17)
        at com.pinterest.ktlint.rule.engine.core.api.RuleId.<init>(Rule.kt:10)

[...]
```